### PR TITLE
Track pipeline device and reload when device changes

### DIFF
--- a/utils/model_manager.py
+++ b/utils/model_manager.py
@@ -8,6 +8,7 @@ class ModelManager:
     """Caches and returns loaded models/pipelines."""
 
     _flux_pipe = None
+    _flux_device = None
     _settings_manager = None
 
     @classmethod
@@ -18,15 +19,30 @@ class ModelManager:
 
     @classmethod
     def get_flux_pipeline(cls, params: dict):
+        settings_manager = cls._get_settings_manager()
+        model_path = params.get('model_path') or settings_manager.get_model_path('flux')
+        requested_device = params.get('device') or settings_manager.get_device()
+        dtype = torch.float16 if requested_device != "cpu" else torch.float32
+
         if cls._flux_pipe is None:
-            settings_manager = cls._get_settings_manager()
-            model_path = params.get('model_path') or settings_manager.get_model_path('flux')
-            device = settings_manager.get_device()
-            dtype = torch.float16 if device != "cpu" else torch.float32
             pipe = StableDiffusionPipeline.from_pretrained(
                 model_path,
                 torch_dtype=dtype,
             )
-            pipe.to(device)
+            pipe.to(requested_device)
             cls._flux_pipe = pipe
+            cls._flux_device = requested_device
+        elif cls._flux_device != requested_device:
+            pipe = cls._flux_pipe
+            try:
+                pipe.to(requested_device)
+            except Exception:
+                pipe = StableDiffusionPipeline.from_pretrained(
+                    model_path,
+                    torch_dtype=dtype,
+                )
+                pipe.to(requested_device)
+                cls._flux_pipe = pipe
+            cls._flux_device = requested_device
+
         return cls._flux_pipe


### PR DESCRIPTION
## Summary
- Track the device used by the cached Flux pipeline
- Reload or move the pipeline when the requested device changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bf39e2d388328891980763ca5644f