### PR TITLE
test: cover os and runtime errors

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -30,3 +30,13 @@ def test_cuda_out_of_memory_message():
     exc = fake_torch.cuda.OutOfMemoryError("CUDA out of memory")
     msg = errors.parse_error(exc)
     assert "CUDA out of memory" in msg
+
+
+def test_os_error_message():
+    msg = errors.parse_error(OSError("permission denied"))
+    assert "OS error" in msg
+
+
+def test_runtime_error_message():
+    msg = errors.parse_error(RuntimeError("boom"))
+    assert "Runtime error" in msg


### PR DESCRIPTION
## Summary
- add tests to ensure `parse_error` handles `OSError` and `RuntimeError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bf58f678c8328bc325b16cad27a18