### PR TITLE
Handle CUDA cache cleanup errors in ImageWorker

### DIFF
--- a/workers/image_and_video_workers.py
+++ b/workers/image_and_video_workers.py
@@ -74,8 +74,10 @@ class ImageWorker(QThread):
             # Ensure GPU memory is freed
             try:
                 torch.cuda.empty_cache()
-            except:
-                pass
+            except (AttributeError, RuntimeError) as exc:
+                from utils.errors import parse_error
+                msg = parse_error(exc)
+                print(msg)
 
     def stop(self):
         """


### PR DESCRIPTION
## Summary
- refine ImageWorker cleanup to explicitly handle `torch.cuda.empty_cache` failures
- log parsed error when CUDA cache clearance fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf6e9149c832882b207f22057bdf2