### PR TITLE
Add lightweight tests for managers and workers

### DIFF
--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -38,9 +38,18 @@ sys.modules.setdefault("diffusers", fake_diffusers)
 # Stub PyQt5 for SettingsManager
 pyqt5 = types.ModuleType("PyQt5")
 qtcore = types.ModuleType("PyQt5.QtCore")
-qtcore.QSettings = type(
-    "QSettings", (), {"__init__": lambda self, *a, **k: None, "value": lambda self, k, d=None: d, "setValue": lambda self, k, v: None}
-)
+
+class FakeQSettings:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def value(self, key, default=None):
+        return default
+
+    def setValue(self, key, value):
+        pass
+
+qtcore.QSettings = FakeQSettings
 sys.modules.setdefault("PyQt5", pyqt5)
 sys.modules.setdefault("PyQt5.QtCore", qtcore)
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1,0 +1,75 @@
+import importlib
+import pathlib
+import sys
+import types
+
+# Stub torch with minimal attributes
+class DummyOOM(RuntimeError):
+    pass
+
+fake_torch = types.SimpleNamespace(
+    float16="float16",
+    float32="float32",
+    cuda=types.SimpleNamespace(OutOfMemoryError=DummyOOM)
+)
+sys.modules["torch"] = fake_torch
+
+# Stub diffusers StableDiffusionPipeline
+class FakePipe:
+    def __init__(self):
+        self.to_calls = []
+    def to(self, device):
+        self.to_calls.append(device)
+        return self
+    def __call__(self, *args, **kwargs):
+        return types.SimpleNamespace(images=[])
+
+class FakeStableDiffusionPipeline:
+    from_pretrained_calls = []
+    @classmethod
+    def from_pretrained(cls, model_path, torch_dtype):
+        cls.from_pretrained_calls.append((model_path, torch_dtype))
+        return FakePipe()
+
+fake_diffusers = types.ModuleType("diffusers")
+fake_diffusers.StableDiffusionPipeline = FakeStableDiffusionPipeline
+sys.modules.setdefault("diffusers", fake_diffusers)
+
+# Stub PyQt5 for SettingsManager
+pyqt5 = types.ModuleType("PyQt5")
+qtcore = types.ModuleType("PyQt5.QtCore")
+qtcore.QSettings = type(
+    "QSettings", (), {"__init__": lambda self, *a, **k: None, "value": lambda self, k, d=None: d, "setValue": lambda self, k, v: None}
+)
+sys.modules.setdefault("PyQt5", pyqt5)
+sys.modules.setdefault("PyQt5.QtCore", qtcore)
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+model_manager = importlib.import_module("utils.model_manager")
+
+
+def setup_function(function):
+    model_manager.ModelManager._flux_pipe = None
+    model_manager.ModelManager._flux_device = None
+    model_manager.ModelManager._settings_manager = None
+    FakeStableDiffusionPipeline.from_pretrained_calls = []
+
+
+def test_loads_and_caches_pipeline():
+    params = {"model_path": "dummy", "device": "cpu"}
+    pipe1 = model_manager.ModelManager.get_flux_pipeline(params)
+    pipe2 = model_manager.ModelManager.get_flux_pipeline(params)
+    assert pipe1 is pipe2
+    assert FakeStableDiffusionPipeline.from_pretrained_calls == [("dummy", "float32")]
+    assert pipe1.to_calls == ["cpu"]
+
+
+def test_moves_pipeline_to_new_device():
+    params = {"model_path": "dummy", "device": "cpu"}
+    pipe1 = model_manager.ModelManager.get_flux_pipeline(params)
+    params2 = {"model_path": "dummy", "device": "cuda"}
+    pipe2 = model_manager.ModelManager.get_flux_pipeline(params2)
+    assert pipe1 is pipe2
+    assert FakeStableDiffusionPipeline.from_pretrained_calls == [("dummy", "float32")]
+    assert pipe1.to_calls == ["cpu", "cuda"]

--- a/tests/test_settings_manager.py
+++ b/tests/test_settings_manager.py
@@ -1,0 +1,39 @@
+import importlib
+import pathlib
+import sys
+import types
+
+# Stub QSettings with in-memory dictionary
+class FakeQSettings:
+    def __init__(self, *args, **kwargs):
+        self.store = {}
+    def value(self, key, default=None):
+        return self.store.get(key, default)
+    def setValue(self, key, value):
+        self.store[key] = value
+
+pyqt5 = types.ModuleType("PyQt5")
+qtcore = types.ModuleType("PyQt5.QtCore")
+qtcore.QSettings = FakeQSettings
+sys.modules["PyQt5"] = pyqt5
+sys.modules["PyQt5.QtCore"] = qtcore
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+settings_manager = importlib.reload(importlib.import_module("utils.settings_manager"))
+
+
+def test_get_and_set():
+    sm = settings_manager.SettingsManager()
+    sm.set("foo", "bar")
+    assert sm.get("foo") == "bar"
+
+
+def test_model_device_and_output_dir():
+    sm = settings_manager.SettingsManager()
+    sm.set_model_path("flux", "/model")
+    assert sm.get_model_path("flux") == "/model"
+    sm.set_device("cuda")
+    assert sm.get_device() == "cuda"
+    sm.set_output_dir("/tmp")
+    assert sm.get_output_dir() == "/tmp"

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -58,10 +58,11 @@ class DummyImage:
     mode = "RGBA"
     width = 1
     height = 1
+    MINIMAL_IMAGE_DATA = b"00"  # Represents minimal image data for testing purposes
     def convert(self, mode):
         return self
     def tobytes(self, *args):
-        return b"00"
+        return self.MINIMAL_IMAGE_DATA
 
 pil = types.ModuleType("PIL")
 image_mod = types.ModuleType("PIL.Image")

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -30,7 +30,7 @@ class QImage:
 pyqt5 = types.ModuleType("PyQt5")
 qtcore = types.ModuleType("PyQt5.QtCore")
 qtcore.QThread = QThread
-qtcore.pyqtSignal = lambda *a, **k: object()
+qtcore.pyqtSignal = DummySignal
 qtgui = types.ModuleType("PyQt5.QtGui")
 qtgui.QImage = QImage
 sys.modules["PyQt5"] = pyqt5


### PR DESCRIPTION
## Summary
- Add unit tests for `ModelManager` covering caching and device switching
- Add `SettingsManager` tests using a stubbed `QSettings`
- Test `ImageWorker` and `VideoWorker` behavior with mocked dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bfc0f3c948328acc16e629a382f94