### PR TITLE
chore: add docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,5 +29,4 @@ __pycache__/
 
 # Miscellaneous
 *.log
-*.pptx
 *.png

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Version control files
+.git
+.gitignore
+.github
+
+# Tests
+tests/
+
+# Documentation
+docs/
+*.md
+
+# Local configuration
+.env
+*.env
+*.local
+.vscode/
+
+# Dependencies and build outputs
+node_modules/
+build/
+dist/
+*.egg-info/
+env/
+.venv/
+PyInstaller*/
+__pycache__/
+*.py[cod]
+
+# Miscellaneous
+*.log
+*.pptx
+*.png


### PR DESCRIPTION
## Summary
- add `.dockerignore` to keep Docker builds focused on runtime files

## Testing
- `pytest` *(fails: DummySignal.__init__() takes 1 positional argument but 2 were given)*

------
https://chatgpt.com/codex/tasks/task_e_688bff49320c8328b0c6130cda3bdd7e