### PR TITLE
Add pre-commit hooks and document workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,26 @@ Generated images are saved to your configured output directory as:
 flux_YYYYMMDD_HHMMSS.png
 ```
 
+## 🔁 Pre-commit
+
+Install git hooks to automatically run linters and type checks before each commit:
+
+```bash
+pre-commit install
+```
+
+Run checks on staged files:
+
+```bash
+pre-commit run --files <file1> [<file2> ...]
+```
+
+Run against the entire codebase:
+
+```bash
+pre-commit run --all-files
+```
+
 ## 🧪 Testing & Linting
 
 ```bash


### PR DESCRIPTION
## Summary
- add pre-commit configuration for Black, Flake8, and Mypy
- document how to install and use pre-commit in the README

## Testing
- `pre-commit run --files readme.md .pre-commit-config.yaml`
- `pytest -q` *(fails: DummySignal.__init__() takes 1 positional argument but 2 were given)*

------
https://chatgpt.com/codex/tasks/task_e_688c02623f448328a6651c19e11dd6d7