### PR TITLE
Use dataclasses for worker parameters

### DIFF
--- a/controllers/main_controller.py
+++ b/controllers/main_controller.py
@@ -7,6 +7,7 @@ from PyQt5.QtCore import Qt
 from ui.main_window import Ui_MainWindow
 from utils.settings_manager import SettingsManager
 from workers.image_and_video_workers import ImageWorker, VideoWorker
+from workers.params import ImageParams, VideoParams
 
 
 class MainController:
@@ -56,17 +57,17 @@ class MainController:
         """Gather UI inputs and launch a worker thread to generate an image."""
         prompt = self.ui.prompt_edit.toPlainText().strip()
         neg = self.ui.neg_prompt_edit.toPlainText().strip()
-        params = {
-            "width": self.ui.width_spin.value(),
-            "height": self.ui.height_spin.value(),
-            "steps": self.ui.steps_spin.value(),
-            "guidance": self.ui.guidance_spin.value(),
-            "model_path": self.settings.get_model_path("flux"),
-            "device": self.ui.device_combo.currentText(),
-            "quantized": self.ui.quant_checkbox.isChecked(),
-        }
+        params = ImageParams(
+            width=self.ui.width_spin.value(),
+            height=self.ui.height_spin.value(),
+            steps=self.ui.steps_spin.value(),
+            guidance=self.ui.guidance_spin.value(),
+            model_path=self.settings.get_model_path("flux"),
+            device=self.ui.device_combo.currentText(),
+            quantized=self.ui.quant_checkbox.isChecked(),
+        )
         # Persist chosen device
-        self.settings.set("device", params["device"])
+        self.settings.set("device", params.device)
 
         # Start worker
         self.image_worker = ImageWorker(prompt, neg, params)
@@ -97,15 +98,15 @@ class MainController:
         """Gather UI inputs and launch a worker thread to generate a video."""
         prompt = self.ui.video_prompt_edit.toPlainText().strip()
         neg = self.ui.video_neg_prompt_edit.toPlainText().strip()
-        params = {
-            "width": self.ui.video_width_spin.value(),
-            "height": self.ui.video_height_spin.value(),
-            "frames": self.ui.frames_spin.value(),
-            "steps": self.ui.video_steps_spin.value(),
-            "offload": self.ui.offload_checkbox.isChecked(),
-            "t5_cpu": self.ui.t5_cpu_checkbox.isChecked(),
-            "precision": self.ui.precision_combo.currentText(),
-        }
+        params = VideoParams(
+            width=self.ui.video_width_spin.value(),
+            height=self.ui.video_height_spin.value(),
+            frames=self.ui.frames_spin.value(),
+            steps=self.ui.video_steps_spin.value(),
+            offload=self.ui.offload_checkbox.isChecked(),
+            t5_cpu=self.ui.t5_cpu_checkbox.isChecked(),
+            precision=self.ui.precision_combo.currentText(),
+        )
 
         self.video_worker = VideoWorker(prompt, neg, params)
         self.video_worker.progress.connect(self.ui.video_progress.setValue)

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2,6 +2,7 @@ import importlib
 import pathlib
 import sys
 import types
+from dataclasses import asdict
 
 # Stub torch with minimal attributes
 class DummyOOM(RuntimeError):
@@ -54,6 +55,7 @@ sys.modules.setdefault("PyQt5", pyqt5)
 sys.modules.setdefault("PyQt5.QtCore", qtcore)
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from workers.params import ImageParams
 
 model_manager = importlib.import_module("utils.model_manager")
 
@@ -66,19 +68,25 @@ def setup_function(function):
 
 
 def test_loads_and_caches_pipeline():
-    params = {"model_path": "dummy", "device": "cpu"}
-    pipe1 = model_manager.ModelManager.get_flux_pipeline(params)
-    pipe2 = model_manager.ModelManager.get_flux_pipeline(params)
+    params = ImageParams(
+        width=1, height=1, steps=1, guidance=1, model_path="dummy", device="cpu"
+    )
+    pipe1 = model_manager.ModelManager.get_flux_pipeline(asdict(params))
+    pipe2 = model_manager.ModelManager.get_flux_pipeline(asdict(params))
     assert pipe1 is pipe2
     assert FakeStableDiffusionPipeline.from_pretrained_calls == [("dummy", "float32")]
     assert pipe1.to_calls == ["cpu"]
 
 
 def test_moves_pipeline_to_new_device():
-    params = {"model_path": "dummy", "device": "cpu"}
-    pipe1 = model_manager.ModelManager.get_flux_pipeline(params)
-    params2 = {"model_path": "dummy", "device": "cuda"}
-    pipe2 = model_manager.ModelManager.get_flux_pipeline(params2)
+    params = ImageParams(
+        width=1, height=1, steps=1, guidance=1, model_path="dummy", device="cpu"
+    )
+    pipe1 = model_manager.ModelManager.get_flux_pipeline(asdict(params))
+    params2 = ImageParams(
+        width=1, height=1, steps=1, guidance=1, model_path="dummy", device="cuda"
+    )
+    pipe2 = model_manager.ModelManager.get_flux_pipeline(asdict(params2))
     assert pipe1 is pipe2
     assert FakeStableDiffusionPipeline.from_pretrained_calls == [("dummy", "float32")]
     assert pipe1.to_calls == ["cpu", "cuda"]

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -109,13 +109,14 @@ sys.modules["utils.model_manager"] = fake_model_manager
 
 # ---- Import workers module ----
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from workers.params import ImageParams, VideoParams
 workers = importlib.import_module("workers.image_and_video_workers")
 
 
 # ---- Tests for ImageWorker ----
 def test_image_worker_emits_progress_and_result():
     empty_cache.called = False
-    params = {"width": 1, "height": 1, "steps": 2, "guidance": 1}
+    params = ImageParams(width=1, height=1, steps=2, guidance=1)
     worker = workers.ImageWorker("prompt", "", params)
     worker.progress = DummySignal()
     worker.result = DummySignal()
@@ -132,13 +133,7 @@ def test_image_worker_passes_quantized_flag():
     fake_model_manager.ModelManager.get_flux_pipeline = (
         lambda params: captured_params.update(params) or FakePipeline()
     )
-    params = {
-        "width": 1,
-        "height": 1,
-        "steps": 1,
-        "guidance": 1,
-        "quantized": True,
-    }
+    params = ImageParams(width=1, height=1, steps=1, guidance=1, quantized=True)
     worker = workers.ImageWorker("prompt", "", params)
     worker.progress = DummySignal()
     worker.result = DummySignal()
@@ -155,11 +150,8 @@ def test_image_worker_emits_error_on_failure():
     fake_model_manager.ModelManager.get_flux_pipeline = (
         lambda params: BadPipeline()
     )  # noqa: E501
-    worker = workers.ImageWorker(
-        "p",
-        "",
-        {"width": 1, "height": 1, "steps": 1, "guidance": 1},
-    )
+    params = ImageParams(width=1, height=1, steps=1, guidance=1)
+    worker = workers.ImageWorker("p", "", params)
     worker.progress = DummySignal()
     worker.result = DummySignal()
     worker.error = DummySignal()
@@ -193,15 +185,15 @@ def test_video_worker_builds_command_and_emits_progress(tmp_path):
     subprocess = importlib.import_module("subprocess")
     subprocess.Popen = fake_popen
 
-    params = {
-        "width": 1,
-        "height": 1,
-        "frames": 1,
-        "steps": 1,
-        "offload": True,
-        "t5_cpu": True,
-        "precision": "fp16",
-    }
+    params = VideoParams(
+        width=1,
+        height=1,
+        frames=1,
+        steps=1,
+        offload=True,
+        t5_cpu=True,
+        precision="fp16",
+    )
     worker = workers.VideoWorker("hello", "", params)
     worker.progress = DummySignal()
     worker.finished = DummySignal()

--- a/workers/params.py
+++ b/workers/params.py
@@ -10,6 +10,7 @@ class ImageParams:
     height: int
     steps: int
     guidance: float
+    # Path to the model file or directory used for image generation.
     model_path: Optional[str] = None
     device: str = "cpu"
     quantized: bool = False

--- a/workers/params.py
+++ b/workers/params.py
@@ -24,6 +24,6 @@ class VideoParams:
     height: int
     frames: int
     steps: int
-    offload: bool = False
-    t5_cpu: bool = False
-    precision: str = "fp16"
+    offload: bool = False  # Whether to offload model weights to CPU when not in use. Useful for memory-constrained environments.
+    t5_cpu: bool = False  # If True, forces the T5 model to run on the CPU regardless of the main device setting.
+    precision: str = "fp16"  # Numerical precision to use for computations. Valid values are "fp16" (half-precision) and "fp32" (full-precision).

--- a/workers/params.py
+++ b/workers/params.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ImageParams:
+    """Parameters controlling image generation."""
+
+    width: int
+    height: int
+    steps: int
+    guidance: float
+    model_path: Optional[str] = None
+    device: str = "cpu"
+    quantized: bool = False
+
+
+@dataclass
+class VideoParams:
+    """Parameters controlling video generation."""
+
+    width: int
+    height: int
+    frames: int
+    steps: int
+    offload: bool = False
+    t5_cpu: bool = False
+    precision: str = "fp16"


### PR DESCRIPTION
## Summary
- introduce `ImageParams` and `VideoParams` dataclasses to centralize worker configuration
- refactor controller and workers to use parameter dataclasses
- update unit tests to construct new parameter objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c1540169083289151d0f5023bca23